### PR TITLE
Point maze env

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ guiding rewards and minimum-time formulation.
 
 ## How to use?
 ```bash
-python sac_experiment.py --env "dm_reacher_easy" --seed 42 --N 201000 --timeout 100 --algo "sac" --replay_buffer_capacity 100000 --results_dir "./results" --experiment_dir "./test" --init_steps 1000
+python sac_experiment.py --env "dm_reacher_easy" --seed 42 --N 201000 --timeout 100 --algo "sac" --replay_buffer_capacity 100000 --results_dir "./results" --init_steps 1000
 ```
 
 ## Compute Canada
@@ -30,5 +30,5 @@ source /home/vasan/src/rtrl/bin/activate
 timeout=50
 env="dm_reacher_easy"
 
-parallel -j 15 python sac_experiment.py --env $env --timeout $timeout --N 205000 --algo "sac" --replay_buffer_capacity 100000 --results_dir "/home/vasan/scratch/min_time_paper/$env" --experiment_dir "./timeout=$timeout" --init_steps 20000 ::: --seed ::: {1..15}
+parallel -j 15 python sac_experiment.py --env $env --timeout $timeout --N 201000 --algo "sac" --replay_buffer_capacity 100000 --results_dir "/home/vasan/scratch/min_time_paper/$env" --init_steps 20000 ::: --seed ::: {1..15}
 ```

--- a/rl_suite/envs/gym_robotics_wrapper.py
+++ b/rl_suite/envs/gym_robotics_wrapper.py
@@ -1,42 +1,98 @@
+"""
+D4RL references:
+- https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/gymnasium_robotics/envs/maze/point_maze.py
+- https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/gymnasium_robotics/envs/maze/maze_v4.py
+"""
+import time
 import gymnasium as gym
+import numpy as np
 
+from rl_suite.envs.dm_control_simple_wrapper import DMControlBaseEnv, Observation
 
 OPEN_DIVERSE_GR = [
     [1, 1, 1, 1, 1, 1, 1],
-    [1, 'C', 'C', 'C', 'C', 'C', 1],
-    [1, 'C', 'C', 'C', 'C', 'C', 1],
-    [1, 'C', 'C', 'C', 'C', 'C', 1],
+    [1, 'c', 'c', 'c', 'c', 'c', 1],
+    [1, 'c', 'c', 'c', 'c', 'c', 1],
+    [1, 'c', 'c', 'c', 'c', 'c', 1],
     [1, 1, 1, 1, 1, 1, 1]
 ]
 
 MEDIUM_MAZE_DIVERSE_GR = [
     [1, 1, 1, 1, 1, 1, 1, 1],
-    [1, 'C', 0, 1, 1, 0, 0, 1],
-    [1, 0, 0, 1, 0, 0, 'C', 1],
+    [1, 'c', 0, 1, 1, 0, 0, 1],
+    [1, 0, 0, 1, 0, 0, 'c', 1],
     [1, 1, 0, 0, 0, 1, 1, 1],
     [1, 0, 0, 1, 0, 0, 0, 1],
-    [1, 'C', 1, 0, 0, 1, 0, 1],
-    [1, 0, 0, 0, 1, 'C', 0, 1],
+    [1, 'c', 1, 0, 0, 1, 0, 1],
+    [1, 0, 0, 0, 1, 'c', 0, 1],
     [1, 1, 1, 1, 1, 1, 1, 1]
 ]
 
 LARGE_MAZE_DIVERSE_GR = [
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
-    [1, 'C', 0, 0, 0, 1, 'C', 0, 0, 0, 0, 1],
+    [1, 'c', 0, 0, 0, 1, 'c', 0, 0, 0, 0, 1],
     [1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1],
-    [1, 0, 0, 0, 0, 'C', 0, 1, 0, 0, 'C', 1],
+    [1, 0, 0, 0, 0, 'c', 0, 1, 0, 0, 'c', 1],
     [1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1],
-    [1, 0, 'C', 1, 0, 1, 0, 0, 0, 0, 0, 1],
+    [1, 0, 'c', 1, 0, 1, 0, 0, 0, 0, 0, 1],
     [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1],
-    [1, 0, 0, 1, 'C', 0, 'C', 1, 0, 'C', 0, 1],
+    [1, 0, 0, 1, 'c', 0, 'c', 1, 0, 'c', 0, 1],
     [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 ]
 
-def main():
+
+class PointMaze(DMControlBaseEnv):
+    all_maps = {"small": OPEN_DIVERSE_GR, "medium": MEDIUM_MAZE_DIVERSE_GR, "large": LARGE_MAZE_DIVERSE_GR}
+    """
+    PointMaze_UMazeDense=v3 uses np.exp(-np.linalg.norm(a-b)) as reward 
+    """
+    def __init__(self, seed, map_type="small", reward_type="sparse", use_image=False) -> None:
+        assert reward_type in ["sparse", "dense"]
+        assert map_type in ["small", "medium", "large"]
+        
+        self.reward_type = reward_type
+        self.use_image = use_image
+        self.seed = seed
+        
+        self.env = gym.make('PointMaze_UMaze-v3', maze_map=self.all_maps[map_type])
+
+        self._obs_dim = 4 if use_image else 6
+        self._action_dim = 2
+    
+    def make_obs(self, x):
+        obs = np.zeros(self._obs_dim, dtype=np.float32)
+        if not self.use_image:
+            obs[:4] = x['observation'].astype(np.float32)
+            obs[4:] = x['desired_goal'].astype(np.float32)
+        else:
+            obs[:4] = x['observation'].astype(np.float32)
+            obs[4:] = x['desired_goal'].astype(np.float32)
+        return obs
+    
+    def reset(self):
+        x = self.env.reset()
+        return self.make_obs(x[0])
+
+    def step(self, action):
+        next_x, r, _, _, info = self.env.step(action)
+        next_obs = self.make_obs(next_x)
+        done = r
+
+        if self.reward_type == "sparse":
+            reward = -1
+        else:
+            reward = -np.linalg.norm(next_x['achieved_goal'] - next_x['desired_goal'])
+
+        return next_obs, reward, done, info
 
 
+def main():    
+    seed = 42
+    np.random.seed(seed)
+
+    env = PointMaze(seed=42, reward_type="dense", map_type="small")
     # env = gym.make('PointMaze_UMaze-v3', maze_map=LARGE_MAZE_DIVERSE_G, render_mode = "human")
-    env = gym.make('PointMaze_UMaze-v3', maze_map=LARGE_MAZE_DIVERSE_GR)
+    
 
     n_episodes = 10
     timeout = 10000
@@ -48,12 +104,14 @@ def main():
         obs = env.reset()
         while (not done and step < timeout):
             action = env.action_space.sample()
-            next_obs, reward, done, truncated, info = env.step(action)
+            next_obs, reward, done, info = env.step(action)
             ret += reward
             step += 1
             obs = next_obs
             # env.render()
-        print("Episode {} ended in {} steps with return {}".format(i_ep+1, step, ret))
+
+        print("Episode {} ended in {} steps with return {:.2f}. Done: {}".format(i_ep+1, step, ret, done))
+        time.sleep(10)
 
 if __name__ == "__main__":
     main()

--- a/rl_suite/envs/gym_robotics_wrapper.py
+++ b/rl_suite/envs/gym_robotics_wrapper.py
@@ -57,7 +57,7 @@ class PointMaze():
         self.use_image = use_image
         if self.use_image and render_mode is None:
             render_mode = "rgb_array"
-            print(f"Visual point_maze_{map_type} with {reward_type} rewards")
+        print(f"point_maze_{map_type} with {reward_type} rewards. Visual task: {use_image}")
 
         self.render_mode = render_mode
         

--- a/rl_suite/envs/gym_robotics_wrapper.py
+++ b/rl_suite/envs/gym_robotics_wrapper.py
@@ -3,11 +3,13 @@ D4RL references:
 - https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/gymnasium_robotics/envs/maze/point_maze.py
 - https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/gymnasium_robotics/envs/maze/maze_v4.py
 """
-import time
+import cv2
 import gymnasium as gym
 import numpy as np
-from gym.spaces import Box
 
+from collections import deque
+from gym.spaces import Box
+from rl_suite.envs import Observation
 
 OPEN_DIVERSE_GR = [
     [1, 1, 1, 1, 1, 1, 1],
@@ -46,36 +48,52 @@ class PointMaze():
     """
     PointMaze_UMazeDense=v3 uses np.exp(-np.linalg.norm(a-b)) as reward 
     """
-    def __init__(self, seed, map_type="small", reward_type="sparse", use_image=False) -> None:
+    def __init__(self, seed, map_type="small", reward_type="sparse", use_image=False, render_mode=None) -> None:
         assert reward_type in ["sparse", "dense"]
         assert map_type in ["small", "medium", "large"]
+        assert render_mode in ["human", "rgb_array", None]
         
         self.reward_type = reward_type
         self.use_image = use_image
+        if self.use_image and render_mode is None:
+            render_mode = "rgb_array"
+            print(f"Visual point_maze_{map_type} with {reward_type} rewards")
+
+        self.render_mode = render_mode
         
-        self.env = gym.make("PointMaze_UMaze-v3", maze_map=self.all_maps[map_type])
+        self.env = gym.make("PointMaze_UMaze-v3", maze_map=self.all_maps[map_type], render_mode=render_mode)
         self.set_seeds(seed)
 
         self._obs_dim = 4 if use_image else 6
         self._action_dim = 2
+        self._img_dim = (160, 160)
     
     def set_seeds(self, seed):
         self.env.reset(seed=seed) # This is just to set the seed
         self.env.action_space.seed(seed)
         
     def make_obs(self, x):
-        obs = np.zeros(self._obs_dim, dtype=np.float32)
-        if not self.use_image:
-            obs[:4] = x['observation'].astype(np.float32)
-            obs[4:] = x['desired_goal'].astype(np.float32)
+        if self.use_image:
+            obs = Observation()
+            obs.images = self.get_image()           
+            obs.proprioception = np.zeros(self._obs_dim, dtype=np.float32)
+            obs.proprioception[:2] = x['observation'].astype(np.float32)[2:]
+            obs.proprioception[2:] = x['desired_goal'].astype(np.float32)
         else:
+            obs = np.zeros(self._obs_dim, dtype=np.float32)
             obs[:4] = x['observation'].astype(np.float32)
             obs[4:] = x['desired_goal'].astype(np.float32)
         return obs
     
+    def get_image(self):
+        assert self.use_image or self.render_mode=="rgb_array"
+        img = self.render()
+        img = cv2.resize(img, self._img_dim, interpolation = cv2.INTER_AREA)
+        img = np.transpose(img, [2, 0, 1])  # c, h, w
+        return img
+
     def reset(self):
-        x = self.env.reset()
-        return self.make_obs(x[0])
+        return self.make_obs(self.env.reset()[0])
 
     def step(self, action):
         next_x, r, _, _, info = self.env.step(action)
@@ -83,15 +101,27 @@ class PointMaze():
         done = r
 
         if self.reward_type == "sparse":
-            reward = -1
+            reward = -1.
         else:
             reward = -np.linalg.norm(next_x['achieved_goal'] - next_x['desired_goal'])
 
         return next_obs, reward, done, info
+    
+    def render(self):
+        if self.render_mode is not None:
+            return self.env.render()
 
     @property
     def observation_space(self):
         return Box(shape=(self._obs_dim,), high=10, low=-10)
+
+    @property
+    def image_space(self):
+        if not self.use_image:
+            raise AttributeError(f'use_image={self.use_image}')
+
+        image_shape = (3, 160, 160)
+        return Box(low=0, high=255, shape=image_shape)
 
     @property
     def proprioception_space(self):
@@ -111,10 +141,9 @@ def main():
     seed = 42
     np.random.seed(seed)
 
-    env = PointMaze(seed=42, reward_type="sparse", map_type="small")
+    env = PointMaze(seed=42, reward_type="sparse", map_type="large", render_mode="rgb_array", use_image=False)
     # env = gym.make('PointMaze_UMaze-v3', maze_map=LARGE_MAZE_DIVERSE_G, render_mode = "human")
     
-
     n_episodes = 10
     timeout = 1000
 
@@ -129,8 +158,8 @@ def main():
             ret += reward
             step += 1
             obs = next_obs
-            # print(f"Obs: {obs}, action: {action}, reward: {reward}")
-            # env.render()
+            print(f"Obs: {obs.shape}, action: {action}, reward: {reward}")
+            env.render()
 
         print("Episode {} ended in {} steps with return {:.2f}. Done: {}".format(i_ep+1, step, ret, done))
     

--- a/rl_suite/envs/gym_robotics_wrapper.py
+++ b/rl_suite/envs/gym_robotics_wrapper.py
@@ -1,0 +1,60 @@
+import gymnasium as gym
+
+
+OPEN_DIVERSE_GR = [
+    [1, 1, 1, 1, 1, 1, 1],
+    [1, 'C', 'C', 'C', 'C', 'C', 1],
+    [1, 'C', 'C', 'C', 'C', 'C', 1],
+    [1, 'C', 'C', 'C', 'C', 'C', 1],
+    [1, 1, 1, 1, 1, 1, 1]
+]
+
+MEDIUM_MAZE_DIVERSE_GR = [
+    [1, 1, 1, 1, 1, 1, 1, 1],
+    [1, 'C', 0, 1, 1, 0, 0, 1],
+    [1, 0, 0, 1, 0, 0, 'C', 1],
+    [1, 1, 0, 0, 0, 1, 1, 1],
+    [1, 0, 0, 1, 0, 0, 0, 1],
+    [1, 'C', 1, 0, 0, 1, 0, 1],
+    [1, 0, 0, 0, 1, 'C', 0, 1],
+    [1, 1, 1, 1, 1, 1, 1, 1]
+]
+
+LARGE_MAZE_DIVERSE_GR = [
+    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+    [1, 'C', 0, 0, 0, 1, 'C', 0, 0, 0, 0, 1],
+    [1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+    [1, 0, 0, 0, 0, 'C', 0, 1, 0, 0, 'C', 1],
+    [1, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1],
+    [1, 0, 'C', 1, 0, 1, 0, 0, 0, 0, 0, 1],
+    [1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1],
+    [1, 0, 0, 1, 'C', 0, 'C', 1, 0, 'C', 0, 1],
+    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+]
+
+def main():
+
+
+    # env = gym.make('PointMaze_UMaze-v3', maze_map=LARGE_MAZE_DIVERSE_G, render_mode = "human")
+    env = gym.make('PointMaze_UMaze-v3', maze_map=LARGE_MAZE_DIVERSE_GR)
+
+    n_episodes = 10
+    timeout = 10000
+
+    for i_ep in range(n_episodes):
+        done = False
+        ret = 0
+        step = 0
+        obs = env.reset()
+        while (not done and step < timeout):
+            action = env.action_space.sample()
+            next_obs, reward, done, truncated, info = env.step(action)
+            ret += reward
+            step += 1
+            obs = next_obs
+            # env.render()
+        print("Episode {} ended in {} steps with return {}".format(i_ep+1, step, ret))
+
+if __name__ == "__main__":
+    main()
+    

--- a/rl_suite/envs/gym_robotics_wrapper.py
+++ b/rl_suite/envs/gym_robotics_wrapper.py
@@ -6,6 +6,7 @@ D4RL references:
 import time
 import gymnasium as gym
 import numpy as np
+from gym.spaces import Box
 
 
 OPEN_DIVERSE_GR = [
@@ -59,7 +60,6 @@ class PointMaze():
         self._action_dim = 2
     
     def set_seeds(self, seed):
-        self.seed = seed        
         self.env.reset(seed=seed) # This is just to set the seed
         self.env.action_space.seed(seed)
         
@@ -88,6 +88,17 @@ class PointMaze():
             reward = -np.linalg.norm(next_x['achieved_goal'] - next_x['desired_goal'])
 
         return next_obs, reward, done, info
+
+    @property
+    def observation_space(self):
+        return Box(shape=(self._obs_dim,), high=10, low=-10)
+
+    @property
+    def proprioception_space(self):
+        if not self.use_image:
+            raise AttributeError(f'use_image={self._use_image}')
+        
+        return self.observation_space
 
     @property
     def action_space(self):

--- a/rl_suite/envs/gym_robotics_wrapper.py
+++ b/rl_suite/envs/gym_robotics_wrapper.py
@@ -52,7 +52,7 @@ class PointMaze():
         self.reward_type = reward_type
         self.use_image = use_image
         
-        self.env = gym.make('PointMaze_UMaze-v3', maze_map=self.all_maps[map_type])
+        self.env = gym.make("PointMaze_UMaze-v3", maze_map=self.all_maps[map_type])
         self.set_seeds(seed)
 
         self._obs_dim = 4 if use_image else 6

--- a/rl_suite/envs/gym_robotics_wrapper.py
+++ b/rl_suite/envs/gym_robotics_wrapper.py
@@ -115,7 +115,7 @@ class PointMaze():
         if self.reward_type == "sparse":
             reward = -1.
         else:
-            reward = np.exp(-np.linalg.norm(next_x['achieved_goal'] - next_x['desired_goal']))
+            reward = -np.linalg.norm(next_x['achieved_goal'] - next_x['desired_goal'])
 
         return next_obs, reward, done, info
     

--- a/rl_suite/experiment.py
+++ b/rl_suite/experiment.py
@@ -22,7 +22,6 @@ from rl_suite.envs.gym_wrapper import MountainCarContinuous
 from rl_suite.envs.dot_seeker import DotSeeker, DotBoxReacher
 from rl_suite.plot.plot import smoothed_curve
 from sys import platform
-from pathlib import Path
 
 # For MacOS
 if platform == "darwin":    
@@ -51,13 +50,9 @@ class Experiment:
         self.run_id += f"_seed-{args.seed}"
         self.args = args
 
-        assert not args.experiment_dir.startswith('/'), 'experiment_dir must use relative path'
+        self._expt_dir = os.path.join(args.results_dir, args.env)
 
-        self._return_dir = Path(args.results_dir)/args.experiment_dir/'returns'
-        self._model_dir = Path(args.results_dir)/args.experiment_dir/'models'
-
-        self.make_dir(self._return_dir)
-        self.make_dir(self._model_dir)
+        self.make_dir(self._expt_dir)
 
         self.save_args()
 
@@ -65,7 +60,7 @@ class Experiment:
         """ Save hyper-parameters as a json file """
         hyperparas_dict = vars(self.args)
         hyperparas_dict["device"] = str(hyperparas_dict["device"])
-        json.dump(hyperparas_dict, open(self._return_dir/f"{self.run_id}_args.json", 'w'), indent=4, cls=NpEncoder)
+        json.dump(hyperparas_dict, open(self._expt_dir/f"{self.run_id}_args.json", 'w'), indent=4, cls=NpEncoder)
 
     def make_env(self):
         if self.args.env == "ball_in_cup":
@@ -80,12 +75,6 @@ class Experiment:
         elif self.args.env == "dm_reacher_torture":
             from rl_suite.envs.dm_control_wrapper import ReacherWrapper
             env = ReacherWrapper(seed=self.args.seed, penalty=self.args.reward, mode="torture", use_image=self.args.use_image)
-        elif self.args.env == "eu_reacher_easy":
-            from rl_suite.envs.dm_control_wrapper import EuclideanReacher
-            env = EuclideanReacher(seed=self.args.seed, penalty=self.args.reward, mode="easy", use_image=self.args.use_image)
-        elif self.args.env == "eu_reacher_hard":
-            from rl_suite.envs.dm_control_wrapper import EuclideanReacher
-            env = EuclideanReacher(seed=self.args.seed, penalty=self.args.reward, mode="hard", use_image=self.args.use_image)
         elif "dot_reacher" in self.args.env:
             if self.args.env == "dot_reacher_easy":
                 self.args.pos_tol = 0.25
@@ -106,27 +95,18 @@ class Experiment:
         elif self.args.env == "mj_reacher":
             from rl_suite.envs.visual_reacher import MJReacherWrapper            
             env = MJReacherWrapper(tol=self.args.tol, penalty=self.args.reward, use_image=self.args.use_image)            
-        elif self.args.env == "acrobot":
-            raise NotImplementedError("Minimum-time env implementation still has many bugs! DO NOT USE!")
-            env = AcrobotWrapper(penalty=self.args.reward, use_image=self.args.use_image, seed=self.args.seed)
-        elif self.args.env == "pendulum":
-            raise NotImplementedError("Minimum-time env implementation still has many bugs! DO NOT USE!")
-            env = PendulumWrapper(penalty=self.args.reward, use_image=self.args.use_image, seed=self.args.seed)
-        elif self.args.env == "gr_reacher_easy":
-            from rl_suite.envs.dm_control_simple_wrapper import DMReacher
-            env = DMReacher(seed=self.args.seed, mode="easy", use_image=self.args.use_image, timeout=self.args.timeout)
-        elif self.args.env == "gr_reacher_hard":
-            env = DMReacher(seed=self.args.seed, mode="hard", use_image=self.args.use_image, timeout=self.args.timeout)
         elif self.args.env == "pick_cube":
             from rl_suite.envs.mani_skill_envs import PickCube
             env = PickCube(seed=self.args.seed, use_image=self.args.use_image)
-        elif self.args.env == "dot_tracker":
+        elif self.args.env == "dot_seeker":
             env = DotSeeker(pos_tol=self.args.pos_tol, penalty=self.args.reward, dt=self.args.dt, 
                              timeout=self.args.timeout, use_image=self.args.use_image)
         elif self.args.env == "dot_box_reacher":
             env = DotBoxReacher(pos_tol=self.args.pos_tol, vel_tol=self.args.vel_tol, penalty=self.args.reward, 
                                 dt=self.args.dt, timeout=self.args.timeout, use_image=self.args.use_image)
-        
+        elif self.args.env == "point_maze":
+            from rl_suite.envs.gym_robotics_wrapper import PointMaze
+            env = PointMaze(seed=self.args.seed, map_type=self.args.maze_type, reward_type=self.args.reward_type, use_image=self.args.use_image)
         else:
             env = gym.make(self.args.env)
             env.seed(self.args.seed)
@@ -144,10 +124,10 @@ class Experiment:
         data = np.zeros((2, len(rets)))
         data[0] = ep_lens
         data[1] = rets
-        np.savetxt(self._return_dir/f'{self.run_id}_returns.txt', data)
+        np.savetxt(self._expt_dir/f'{self.run_id}_returns.txt', data)
     
     def save_model(self, step):
-        self.learner.save(self._model_dir, step)
+        self.learner.save(self._expt_dir, step)
 
     def set_seed(self):
         seed = self.args.seed
@@ -180,7 +160,7 @@ class Experiment:
                 plt.plot(plot_x, plot_rets)
                 plt.pause(0.001)
                 if save_fig:
-                    plt.savefig(self._return_dir/f"{self.run_id}_learning_curve.png")
+                    plt.savefig(self._expt_dir/f"{self.run_id}_learning_curve.png")
     
     def run(self):
         """ This needs to be algorithm specific """

--- a/rl_suite/experiment.py
+++ b/rl_suite/experiment.py
@@ -49,11 +49,8 @@ class Experiment:
         self.run_id = datetime.now().strftime("%Y-%m-%d-%H_%M_%S")
         self.run_id += f"_seed-{args.seed}"
         self.args = args
-
         self._expt_dir = os.path.join(args.results_dir, args.env)
-
         self.make_dir(self._expt_dir)
-
         self.save_args()
 
     def save_args(self):
@@ -124,7 +121,7 @@ class Experiment:
         data = np.zeros((2, len(rets)))
         data[0] = ep_lens
         data[1] = rets
-        np.savetxt(self._expt_dir/f'{self.run_id}_returns.txt', data)
+        np.savetxt(f"{self._expt_dir}/{self.run_id}_returns.txt", data)
     
     def save_model(self, step):
         self.learner.save(self._expt_dir, step)
@@ -160,7 +157,7 @@ class Experiment:
                 plt.plot(plot_x, plot_rets)
                 plt.pause(0.001)
                 if save_fig:
-                    plt.savefig(self._expt_dir/f"{self.run_id}_learning_curve.png")
+                    plt.savefig(f"{self._expt_dir}/{self.run_id}_learning_curve.png")
     
     def run(self):
         """ This needs to be algorithm specific """

--- a/rl_suite/experiment.py
+++ b/rl_suite/experiment.py
@@ -60,7 +60,7 @@ class Experiment:
         """ Save hyper-parameters as a json file """
         hyperparas_dict = vars(self.args)
         hyperparas_dict["device"] = str(hyperparas_dict["device"])
-        json.dump(hyperparas_dict, open(self._expt_dir/f"{self.run_id}_args.json", 'w'), indent=4, cls=NpEncoder)
+        json.dump(hyperparas_dict, open(os.path.join(self._expt_dir, "{}_args.json".format(self.run_id)), 'w'), indent=4, cls=NpEncoder)
 
     def make_env(self):
         if self.args.env == "ball_in_cup":

--- a/rl_suite/plot/plot_hits_vs_timeout.py
+++ b/rl_suite/plot/plot_hits_vs_timeout.py
@@ -1,9 +1,46 @@
 import seaborn as sns
 import matplotlib.pyplot as plt
 import re
-import pandas as pd
 
+# Ignore annoying pandas warning
+import warnings
+warnings.simplefilter(action='ignore', category=FutureWarning)
+
+import pandas as pd
 from pathlib import Path
+
+# Assign colors for each choice of timeout
+color_dict = {
+    # simulation colors
+    1:      'tab:blue',
+    2:      'tab:orange',
+    5:      'tab:green',
+    10:     'tab:red',
+    25:     'tab:purple', 
+    50:     'tab:brown', 
+    100:    'tab:pink', 
+    500:    'tab:gray', 
+    1000:   'tab:olive', 
+    5000:   'tab:cyan',
+    10000:  'orangered',
+    20000:  'midnightblue',
+    # real robot colors
+    '3s':      'tab:blue',
+    '6s':      'tab:orange',
+    '15s':     'tab:red',
+    '30s':     'tab:green',
+}
+
+def human_format_numbers(num, use_float=False):
+    # Make human readable short-forms for large numbers
+    magnitude = 0
+    while abs(num) >= 1000:
+        magnitude += 1
+        num /= 1000.0
+    # add more suffixes if you need them
+    if use_float:
+        return '%.2f%s' % (num, ['', 'K', 'M', 'G', 'T', 'P'][magnitude])
+    return '%d%s' % (num, ['', 'K', 'M', 'G', 'T', 'P'][magnitude])
 
 def find_files_and_plot():
     """ Yan's original script preserved for posterity """
@@ -27,8 +64,9 @@ def find_files_and_plot():
         plt.close()
 
 def hits_vs_timeout():
-    env = "pendulum"
-    bp = "/home/vasan/src/rl_suite/rl_suite/plot"
+    env = "point_maze_large"
+    # bp = "/home/vasan/src/rl_suite/rl_suite"
+    bp = "/Users/gautham/src/rl_suite/rl_suite"   # MacOS
     fp = bp + f"/{env}_random_stat.txt"
 
     df = pd.DataFrame(columns=["timeout", "seed", "hits"])
@@ -43,9 +81,13 @@ def hits_vs_timeout():
     plt.title(env)
     plt.xlabel('Timeout')
     plt.ylabel('Hits')
-    ax = sns.barplot(data=df, x='timeout', y='hits')
-    ax.bar_label(ax.containers[0])
+    ax = sns.barplot(data=df, x='timeout', y='hits', palette=color_dict)
+    # ax.bar_label(ax.containers[0])
+    labels = ax.get_xticklabels()
+    new_labels = [human_format_numbers(int(k._text)) for k in labels] 
+    ax.set_xticklabels(new_labels)
     plt.savefig(f'{env}.png')
+    plt.show()
     plt.close()
 
 if __name__ == "__main__":

--- a/rl_suite/sac_experiment.py
+++ b/rl_suite/sac_experiment.py
@@ -91,7 +91,7 @@ class SACExperiment(Experiment):
         parser.add_argument('--rad_offset', default=0.01, type=float)
         parser.add_argument('--freeze_cnn', default=0, type=int)
         # Misc
-        parser.add_argument('--init_policy_test', action='store_true', type="bool", help="Initiate hits vs timeout test")
+        parser.add_argument('--init_policy_test', action='store_true', help="Initiate hits vs timeout test")
         parser.add_argument('--results_dir', required=True, type=str, help="Save results to this dir")
         parser.add_argument('--xlimit', default=None, type=str)
         parser.add_argument('--ylimit', default=None, type=str)
@@ -241,7 +241,7 @@ class SACExperiment(Experiment):
 
     def _run_init_policy_test(self):
         """ N.B: Use only for minimum-time tasks """
-        timeouts = [1, 2, 5, 10, 25, 50, 100, 500, 1000, 5000]
+        timeouts = [1, 2, 5, 10, 25, 50, 100, 500, 1000, 5000, 10000, 20000]
         total_steps = 20000
         steps_record = open(f"{self.args.env}_steps_record.txt", 'w')
         hits_record = open(f"{self.args.env}_random_stat.txt", 'w')
@@ -258,8 +258,9 @@ class SACExperiment(Experiment):
                 epi_steps = 0
                 obs = self.env.reset()
                 while steps < total_steps:
-                    # action = self.learner.sample_action(obs)
-                    action = np.random.normal(size=self.env.action_space.shape)
+                    action = self.learner.sample_action(obs)
+                    # action = np.random.normal(size=self.env.action_space.shape)
+                    
                     # Receive reward and next state            
                     _, _, done, _ = self.env.step(action)
                     

--- a/rl_suite/sac_experiment.py
+++ b/rl_suite/sac_experiment.py
@@ -55,7 +55,10 @@ class SACExperiment(Experiment):
         parser.add_argument('--pos_tol', default=0.1, type=float, help="Position tolerance in [0.05, ..., 0.25]")
         parser.add_argument('--vel_tol', default=0.05, type=float, help="Velocity tolerance in [0.05, ..., 0.1]")
         parser.add_argument('--dt', default=0.2, type=float, help="Simulation action cycle time")
-        parser.add_argument('--clamp_action', default=1, type=int, help="Clamp action space")        
+        parser.add_argument('--clamp_action', default=1, type=int, help="Clamp action space")    
+        ## Point Maze
+        parser.add_argument('--maze_type', default="small", type=str, help= "Maze type in ['small', 'medium', 'large']")
+        parser.add_argument('--reward_type', default="sparse", type=str, help= "Reward type in ['sparse', 'dense']")
         # Algorithm
         parser.add_argument('--algo', required=True, type=str, help="Choices: ['sac', 'sac_rad']")
         parser.add_argument('--replay_buffer_capacity', required=True, type=int)
@@ -88,9 +91,8 @@ class SACExperiment(Experiment):
         parser.add_argument('--rad_offset', default=0.01, type=float)
         parser.add_argument('--freeze_cnn', default=0, type=int)
         # Misc
-        parser.add_argument('--run_type', default='experiment', type=str, help="Which test to run")
+        parser.add_argument('--init_policy_test', action='store_true', type="bool", help="Initiate hits vs timeout test")
         parser.add_argument('--results_dir', required=True, type=str, help="Save results to this dir")
-        parser.add_argument('--experiment_dir', required=True, type=str, help="Save experiment outputs, relative to result_dir")
         parser.add_argument('--xlimit', default=None, type=str)
         parser.add_argument('--ylimit', default=None, type=str)
         parser.add_argument('--checkpoint', default=5000, type=int, help="Save plots and rets every checkpoint")
@@ -149,15 +151,13 @@ class SACExperiment(Experiment):
         return args
 
     def run(self):
-        if self.args.run_type == 'experiment':
-            self._run_experiment()
-            print("{}-{} run with {} steps starts now ...".format(self.args.env, self.args.algo, self.args.N))
-        elif self.args.run_type == 'init_policy_test':
-            self._run_init_policy_test()
+        if self.args.init_policy_test:
             print("Initial policy test")
+            self._run_init_policy_test()
         else:
-            raise NotImplementedError()
-
+            print("{}-{} run with {} steps starts now ...".format(self.args.env, self.args.algo, self.args.N))
+            self._run_experiment()
+            
     def _run_experiment(self):
         # Normalize wrapper
         rms = RunningStats()


### PR DESCRIPTION
Adding point_maze env for benchmarking the minimum-time formulation

TODO:
- [x] PointMaze wrapper class to be used for experiments
- [x] Reproducibility fix: set seed at the appropriate location
- [x] Random policy tests with all three mazes. Estimate the initial policy success rate
- [x] Turn on/off the rendering feature
- [x] Support image observations
- [x] Learning with guiding rewards where the task ends as soon as we reach the goal (no images, small maze)
- [x] Learning in minimum-time formulation (no images, small maze)